### PR TITLE
feat: use haiku for intent routing and fix Dockerfile sdk-python-gowa…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc,mode=0600 \
     --mount=type=bind,source=./uv.lock,target=uv.lock \
     --mount=type=bind,source=./pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=./.python-version,target=.python-version \
+    --mount=type=bind,source=./sdk-python-gowa,target=sdk-python-gowa \
     uv sync --frozen --no-dev --no-install-project
 
 COPY . /app

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
 
     # Model settings
     model_name: str = "anthropic:claude-sonnet-4-5-20250929"
+    router_model_name: str = "anthropic:claude-haiku-4-5-20251001"
 
     # Direct Message settings
     dm_autoreply_enabled: bool = False

--- a/src/handler/router.py
+++ b/src/handler/router.py
@@ -72,7 +72,7 @@ class Router(BaseHandler):
 
     async def _route(self, message: str) -> IntentEnum:
         agent = Agent(
-            model=self.settings.model_name,
+            model=self.settings.router_model_name,
             system_prompt=prompt_manager.render("intent.j2"),
             output_type=Intent,
         )


### PR DESCRIPTION
1. Dockerfile — mount sdk-python-gowa during build so uv sync can resolve the local
  dependency
2. Config — new router_model_name setting defaulting to Haiku, so it can be changed from one
  place via env var ROUTER_MODEL_NAME
3. Router — uses router_model_name instead of model_name for intent classification
