### PR TITLE
fix: parse bot JID from new gowa device response shape

### DIFF
--- a/src/api/status.py
+++ b/src/api/status.py
@@ -52,10 +52,14 @@ async def status(
                 "device_count": 0,
             }
         else:
+            # Ensure the primary device JID is actually parseable — webhook
+            # handling depends on it (see WhatsAppClient.get_my_jid).
+            my_jid = await whatsapp.get_my_jid()
             health_data["checks"]["whatsapp"] = {
                 "status": "healthy",
                 "duration_seconds": devices_duration,
                 "device_count": len(devices_response.results),
+                "bot_jid": str(my_jid),
                 "devices": [
                     {"name": device.name, "device": device.device}
                     for device in devices_response.results

--- a/src/handler/__init__.py
+++ b/src/handler/__init__.py
@@ -42,6 +42,10 @@ class MessageHandler(BaseHandler):
     async def __call__(self, payload: WebhookEnvelope):
         message = await self.store_message(payload)
 
+        # Persist immediately: a failure later in the handler must not roll
+        # back the stored message (it would be lost for the daily summary).
+        await self.session.commit()
+
         # ignore messages that don't exist or don't have text
         if not message or not message.text:
             return

--- a/src/whatsapp/client.py
+++ b/src/whatsapp/client.py
@@ -19,7 +19,10 @@ class WhatsAppClient(GoWaClient):
         info = await self.get_devices()
         if not info.results:
             raise ValueError("No devices found")
-        device_jid = info.results[0].device
+        # Newer gowa versions return the WhatsApp JID in `jid` and an internal
+        # device UUID in `device`; older versions put the JID in `device`.
+        result = info.results[0]
+        device_jid = getattr(result, "jid", None) or result.device
         if not device_jid:
             raise ValueError("No primary device JID found")
         self._jid = parse_jid(device_jid)

--- a/src/whatsapp/test_client.py
+++ b/src/whatsapp/test_client.py
@@ -49,7 +49,9 @@ async def test_get_user_info(client: WhatsAppClient, httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
-async def test_get_my_jid_new_device_shape(client: WhatsAppClient, httpx_mock: HTTPXMock):
+async def test_get_my_jid_new_device_shape(
+    client: WhatsAppClient, httpx_mock: HTTPXMock
+):
     """Newer gowa returns a device UUID in `device` and the JID in `jid`."""
     httpx_mock.add_response(
         url="http://test-api/app/devices",

--- a/src/whatsapp/test_client.py
+++ b/src/whatsapp/test_client.py
@@ -49,6 +49,48 @@ async def test_get_user_info(client: WhatsAppClient, httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_get_my_jid_new_device_shape(client: WhatsAppClient, httpx_mock: HTTPXMock):
+    """Newer gowa returns a device UUID in `device` and the JID in `jid`."""
+    httpx_mock.add_response(
+        url="http://test-api/app/devices",
+        json={
+            "code": "SUCCESS",
+            "message": "Fetch device success",
+            "results": [
+                {
+                    "name": "llm.org.il",
+                    "device": "d44c0c8b-8443-4128-a9d7-1708db4c2020",
+                    "jid": "972545380874@s.whatsapp.net",
+                }
+            ],
+        },
+    )
+    jid = await client.get_my_jid()
+    assert jid.user == "972545380874"
+    assert jid.server == "s.whatsapp.net"
+
+
+@pytest.mark.asyncio
+async def test_get_my_jid_legacy_device_shape(
+    client: WhatsAppClient, httpx_mock: HTTPXMock
+):
+    """Older gowa returns the JID directly in `device`."""
+    httpx_mock.add_response(
+        url="http://test-api/app/devices",
+        json={
+            "code": "SUCCESS",
+            "message": "Fetch device success",
+            "results": [
+                {"name": "llm.org.il", "device": "972545380874@s.whatsapp.net"}
+            ],
+        },
+    )
+    jid = await client.get_my_jid()
+    assert jid.user == "972545380874"
+    assert jid.server == "s.whatsapp.net"
+
+
+@pytest.mark.asyncio
 async def test_send_message(client: WhatsAppClient, httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://test-api/send/message",


### PR DESCRIPTION
## Problem

Since Aug 9, every text-message webhook returned 500 (~300–1,000/day), and the daily summary had no messages to summarize.

Root cause (traced via Logfire): the gowa server's `/app/devices` response changed shape. The `device` field now holds an internal device UUID, and the WhatsApp JID moved to a new `jid` field:

```json
{"name": "llm.org.il", "device": "d44c0c8b-8443-4128-a9d7-1708db4c2020", "jid": "972545380874@s.whatsapp.net"}
```

`WhatsAppClient.get_my_jid()` still parsed `device`, raising `JIDParseError` on every call. Worse, the exception rolled back the request's DB session **after** `store_message()` had run — so every inbound text message was silently discarded, which is why the daily summary was empty. The `/status` health check kept reporting healthy because it only checked that the device list was non-empty, never that the JID parsed.

## Fix

- `get_my_jid()` prefers the new `jid` field and falls back to `device` for older gowa versions (the SDK model uses `extra="allow"`, so the undeclared field is preserved)
- `MessageHandler.__call__` commits immediately after `store_message`, so a downstream failure can no longer roll back and lose the inbound message (safe: sessionmaker uses `expire_on_commit=False` and relationships are `lazy="selectin"`, already loaded)
- `/status` now parses the bot JID and includes `bot_jid` in the payload, so a shape regression flips the health check to 503 instead of passing while messages get dropped
- Regression tests for both device response shapes (new test uses the exact production payload)

## Notes

- Messages received between Aug 9 and deploy were never committed and are unrecoverable from our DB
- All 51 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)